### PR TITLE
updateと新規追加したnpmの表示

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,80 @@
+#! /usr/bin/env node
+
+const lockfile = require('yarn-lockfile');
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+
+function npmName(spec) {
+  return spec.split('@')[0];
+}
+
+function formatedHash(obj) {
+  const dst = {};
+  Object.keys(obj).forEach(function(key) {
+    name = npmName(key);
+    dst[name] = { name: npmName(key), version: obj[key].version };
+  });
+  return dst;
+};
+
+function readGitYarn(version) {
+  let string = execSync(`git show ${version}:yarn.lock`).toString();
+  let json = lockfile.parse(string);
+  return json;
+}
+
+function parse(file) {
+  let string = fs.readFileSync(file, 'utf8');
+  let json = lockfile.parse(string);
+  return json;
+}
+
+function diffs(previous, current) {
+  const previousArray = formatedHash(previous);
+  const currentArray = formatedHash(current);
+
+  let exists = false;
+  const addedHash = {};
+  const updatedHash = {};
+
+  Object.keys(currentArray).forEach(function(curr, i) {
+    exists = false;
+
+    Object.keys(previousArray).forEach(function(prev, j) {
+
+      if (currentArray[curr].name === previousArray[prev].name) {
+        exists = true;
+        if (currentArray[curr].version !== previousArray[prev].version) {
+          updatedHash[curr] = {
+            previous: previousArray[prev].version,
+            current: currentArray[curr].version,
+          };
+        }
+        return;
+      }
+    });
+
+    if (!exists) {
+      addedHash[curr] = {
+        previous: '',
+        current: currentArray[curr].version,
+      }
+    }
+  });
+
+
+  return Object.assign(updatedHash, addedHash);
+}
+
+if (process.argv.length < 4) {
+  console.log('Usage: yarn-diff previous current');
+  console.log('previous current is git commit number');
+  process.exit();
+}
+
+const previousVersion = process.argv[2];
+const currentVersion = process.argv[3];
+const previousJson = readGitYarn(previousVersion);
+const currentJson = readGitYarn(currentVersion);
+
+console.log(JSON.stringify(diffs(previousJson, currentJson)));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "yarn-diff",
+  "version": "1.0.0",
+  "description": "",
+  "preferGlobal": true,
+  "bin": {
+    "yarn-diff": "main.js"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Koishi Masato",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/koishimasato/yarn-diff"
+  },
+  "engines": {
+    "node": ">= 6.3.0",
+    "yarn": ">= 0.20.3"
+  },
+  "dependencies": {
+    "yarn-lockfile": "^1.0.0"
+  }
+}


### PR DESCRIPTION
yarn.lockの差分を表示する。

例:

[git][* feature/bundle_diff]:~/dev/fujossy/ $ yarn-diff HEAD^^ HEAD | jq
{
  "ansi-escapes": {
    "previous": "1.4.0",
    "current": "2.0.0"
  },
  "bytes": {
    "previous": "2.3.0",
    "current": "2.5.0"
  },
  "camelcase": {
    "previous": "3.0.0",
    "current": "4.1.0"
  },
  "mimic-fn": {
    "previous": "",
    "current": "1.1.0"
  },
  "node-emoji": {
    "previous": "",
    "current": "1.5.1"
  },
  "object-path": {
    "previous": "",
    "current": "0.11.4"
  },
  "peek-stream": {
    "previous": "",
    "current": "1.1.2"
  },
  "proper-lockfile": {
    "previous": "",
    "current": "2.0.1"
  },
}